### PR TITLE
Fixed PART throwing a nullref if user_read scope is not present.

### DIFF
--- a/src/NTwitch.Chat/TwitchChatClient.cs
+++ b/src/NTwitch.Chat/TwitchChatClient.cs
@@ -185,7 +185,7 @@ namespace NTwitch.Chat
                             var cacheChannel = new Cacheable<string, ChatSimpleChannel>(channel, model.ChannelName, channel != null);
                             var cacheUser = new Cacheable<string, ChatSimpleUser>(user, model.UserName, user != null);
 
-                            if (CurrentUser.Name == model.UserName)
+                            if (TokenInfo.Username == model.UserName)
                                 await _currentUserLeftEvent.InvokeAsync(cacheChannel).ConfigureAwait(false);
                             else
                                 await _userLeftEvent.InvokeAsync(cacheChannel, cacheUser).ConfigureAwait(false);


### PR DESCRIPTION
#### Description
Previously, we used `CurrentUser` to check if the user parting is the user logged in. This only worked in cases where the `user_read` scope was present, since that was the only case `CurrentUser` was set: https://github.com/Aux/NTwitch/blob/678b5a2f59db38fc6392f7fe1a950577b14bbfed/src/NTwitch.Rest/BaseTwitchClient.cs#L102-L103
This commit changes checking from the `CurrentUser` to the `TokenInfo`.

#### Motivation and Context
Previously, if we received a PART message and the `user_read` scope was not present, a null reference exception would have been raised. This change fixes that.

#### How Has This Been Tested?
Tested with Program.cs in tests/, no changes except filling in token.

On the current master branch, joining any high viewer count channel will lead to a lot of nullrefs in the log, also tested with 2 different accounts.

On this branch, no nullrefs are raised when a user leaves, and the test method `OnUserLeftAsync` successfully completes.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.