### PR TITLE
Hotfix for parsing host events when viewer count is not sent.

### DIFF
--- a/src/NTwitch.Chat/API/Models/HostEvent.cs
+++ b/src/NTwitch.Chat/API/Models/HostEvent.cs
@@ -22,7 +22,8 @@ namespace NTwitch.Chat.API
             HostName = msg.Parameters.First().Substring(1).Trim();
 
             var split = msg.Parameters.Last().Split(' ');
-            Viewers = int.Parse(split.Last());
+            if (int.TryParse(split.Last(), out var viewers))
+                Viewers = viewers;
 
             if (split.First() != "-")
                 ChannelName = split.First();


### PR DESCRIPTION
#### Description
Converted the unsafe `int.Parse()` into `int.TryParse()`

#### Motivation and Context
Occasionally, Twitch will send a HOST event with no viewers present (ex: `HOSTTARGET #shul inexpensivegamer -`), in these cases, an exception will be thrown.

A side effect of this change is that the event will report a 0 viewer host, when in fact there may be viewers. More investigation is required on this issue.

#### How Has This Been Tested?
Ran a bot for about 30 minutes, with cases of no viewer numbers provided, and no exceptions were thrown. 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.